### PR TITLE
Fixed diatom/datomic mixing, numpy.complex deprecation

### DIFF
--- a/diatomic/calculate.py
+++ b/diatomic/calculate.py
@@ -1,4 +1,4 @@
-import diatom.hamiltonian as hamiltonian
+from . import hamiltonian
 import numpy
 import scipy.constants
 from sympy.physics.wigner import wigner_3j
@@ -179,7 +179,7 @@ def dipole(Nmax,I1,I2,d,M):
         Dmat (numpy.ndarray) - dipole matrix
     '''
     shape = numpy.sum(numpy.array([2*x+1 for x in range(0,int(Nmax+1))]))
-    dmat = numpy.zeros((shape,shape),dtype= numpy.complex)
+    dmat = numpy.zeros((shape,shape), dtype=complex)
     i =0
     j =0
     for N1 in range(0,int(Nmax+1)):

--- a/diatomic/hamiltonian.py
+++ b/diatomic/hamiltonian.py
@@ -128,7 +128,7 @@ def vector_dot(x,y):
         Returns:
             Z (numpy.ndarray): result of the dot product, JxJ array
     '''
-    x_y = numpy.zeros(x[0].shape,dtype=numpy.complex)
+    x_y = numpy.zeros(x[0].shape,dtype=complex)
     for i in range(x.shape[0]):
         x_y += numpy.dot(x[i],y[i])
     return x_y
@@ -520,7 +520,7 @@ def dc(Nmax,d0,I1,I2):
      '''
 
     shape = numpy.sum(numpy.array([2*x+1 for x in range(0,Nmax+1)]))
-    HDC = numpy.zeros((shape,shape),dtype= numpy.complex)
+    HDC = numpy.zeros((shape,shape),dtype=complex)
 
     I1shape = int(2*I1+1)
     I2shape = int(2*I2+1)
@@ -563,7 +563,7 @@ def ac_iso(Nmax,a0,I1,I2):
     shape = numpy.sum(numpy.array([2*x+1 for x in range(0,Nmax+1)]))
     I1shape = int(2*I1+1)
     I2shape = int(2*I2+1)
-    HAC = numpy.zeros((shape,shape),dtype= numpy.complex)
+    HAC = numpy.zeros((shape,shape), dtype=complex)
     i=0
     j=0
     for N1 in range(0,Nmax+1):
@@ -607,7 +607,7 @@ def ac_aniso(Nmax,a2,Beta,I1,I2):
     I1shape = int(2*I1+1)
     I2shape = int(2*I2+1)
     shape = numpy.sum(numpy.array([2*x+1 for x in range(0,Nmax+1)]))
-    HAC = numpy.zeros((shape,shape),dtype= numpy.complex)
+    HAC = numpy.zeros((shape,shape), dtype=complex)
     i=0
     j=0
     for N1 in range(0,Nmax+1):

--- a/diatomic/plotting.py
+++ b/diatomic/plotting.py
@@ -1,8 +1,8 @@
 from matplotlib import pyplot,gridspec,colors,patches,collections
 import numpy
 import warnings
-import diatom.calculate as calculate
-import diatom.hamiltonian as hamiltonian
+from . import calculate
+from . import hamiltonian
 from scipy import constants
 
 h = constants.h

--- a/example scripts/example_ac_stark.py
+++ b/example scripts/example_ac_stark.py
@@ -1,7 +1,7 @@
 import numpy
 from matplotlib import pyplot
-import diatom.hamiltonian as hamiltonian
-from diatom.constants import Rb87Cs133
+import diatomic.hamiltonian as hamiltonian
+from diatomic.constants import Rb87Cs133
 from numpy.linalg import eigh
 from scipy import constants
 from matplotlib.collections import LineCollection
@@ -81,7 +81,7 @@ for i in range(numpy.shape(energies)[1]):
     pyplot.plot(I/1e7, (energies[:,i]-numpy.amin(energies))/(1e6*h), linestyle='solid', color='lightgray', zorder=0)
     
     #add colour on top to indicate the component that has N=1, MN=1, IRb=3/2, ICs=7/2
-    cl=colorline(I/1e7,(energies[:,i]-numpy.amin(energies))/(1e6*h),z=abs(numpy.real(states[:,32,i])),cmap='RbCs_map_blue',norm=LogNorm(vmin=1e-2,vmax=1),linewidth=2.0)
+    cl=colorline(I/1e7,(energies[:,i]-numpy.amin(energies))/(1e6*h),z=abs(numpy.real(states[:,32,i])),norm=LogNorm(vmin=1e-2,vmax=1),linewidth=2.0)
 
    
 

--- a/example scripts/example_dc.py
+++ b/example scripts/example_dc.py
@@ -4,8 +4,8 @@
 
 import numpy
 import matplotlib.pyplot as pyplot
-import diatom.hamiltonian as hamiltonian
-from diatom.constants import Rb87Cs133
+import diatomic.hamiltonian as hamiltonian
+from diatomic.constants import Rb87Cs133
 from scipy.constants import h
 from numpy.linalg import eigh
 

--- a/example scripts/example_electric_moment.py
+++ b/example scripts/example_electric_moment.py
@@ -1,9 +1,9 @@
 import numpy
 import matplotlib.pyplot as pyplot
-import diatom.hamiltonian as hamiltonian
-from diatom.constants import Rb87Cs133
+import diatomic.hamiltonian as hamiltonian
+from diatomic.constants import Rb87Cs133
 from numpy.linalg import eigh
-import calculate as calculate
+import diatomic.calculate as calculate
 import scipy.constants 
 
 muN = scipy.constants.physical_constants['nuclear magneton'][0]

--- a/example scripts/example_magnetic_moment.py
+++ b/example scripts/example_magnetic_moment.py
@@ -1,9 +1,9 @@
 import numpy
 import matplotlib.pyplot as pyplot
-import diatom.hamiltonian as hamiltonian
-from constants import Rb87Cs133
+import diatomic.hamiltonian as hamiltonian
+from diatomic.constants import Rb87Cs133
 from numpy.linalg import eigh
-import diatom.calculate as calculate
+import diatomic.calculate as calculate
 import scipy.constants 
 
 muN = scipy.constants.physical_constants['nuclear magneton'][0]

--- a/example scripts/example_transition_plot.py
+++ b/example scripts/example_transition_plot.py
@@ -5,9 +5,9 @@ Note, this uses the transition_plot function from the plotting.py module!
 '''
 
 from numpy.linalg import eigh
-import diatom.plotting as plotting
-import diatom.hamiltonian as hamiltonian
-from diatom.constants import Rb87Cs133
+import diatomic.plotting as plotting
+import diatomic.hamiltonian as hamiltonian
+from diatomic.constants import Rb87Cs133
 import matplotlib.pyplot as pyplot
 
 Nmax=4

--- a/example scripts/example_zeeman.py
+++ b/example scripts/example_zeeman.py
@@ -2,8 +2,8 @@
 
 import numpy
 import matplotlib.pyplot as pyplot
-import diatom.hamiltonian as hamiltonian
-from diatom.constants import Rb87Cs133
+import diatomic.hamiltonian as hamiltonian
+from diatomic.constants import Rb87Cs133
 from scipy.constants import h
 from numpy.linalg import eigh
 


### PR DESCRIPTION
A clean install of `diatomic` wouldn't work, because it referred to the `diatom` package which no longer existed. Additionally, numpy.complex no longer exists in recent versions of numpy. The changes here attempt to resolve these issues.