### PR TITLE
Dec 2025 Bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,9 @@ docs/_build/
 .pybuilder/
 target/
 
+# VsCode
+.vscode/
+
 # Jupyter Notebook
 .ipynb_checkpoints
 

--- a/examples/zeeman.py
+++ b/examples/zeeman.py
@@ -8,6 +8,7 @@ import diatomic.operators as operators
 import diatomic.calculate as calculate
 from diatomic.plotting import colorline
 
+
 GAUSS = 1e-4  # T
 MHz = scipy.constants.h * 1e6
 muN = scipy.constants.physical_constants["nuclear magneton"][0]
@@ -16,7 +17,7 @@ muN = scipy.constants.physical_constants["nuclear magneton"][0]
 diatomic.configure_logging()
 
 # Generate Molecule
-mol = SingletSigmaMolecule.from_preset("Rb87Cs133")
+mol = SingletSigmaMolecule.from_preset("Na23Cs133")
 mol.Nmax = 1
 
 # Generate Hamiltonians
@@ -39,7 +40,7 @@ eigenlabels = calculate.label_states(mol, eigenstates[-1], ["N", "MF"])
 
 magnetic_moments = calculate.magnetic_moment(mol, eigenstates)
 
-groundstate = 0
+groundstate = 1
 transition_sigma_plus = calculate.transition_electric_moments(
     mol, eigenstates[:, :, :], h=1, from_states=groundstate
 )
@@ -69,7 +70,7 @@ h = [transition_sigma_plus, transition_pi, transition_sigma_minus]
 for c, rgbi, transition_elements in zip(cs, rgbis, h):
     axdr.plot(
         B / GAUSS,
-        transition_elements[:, groundstate, :] / mol.d0,
+        transition_elements[:, 0, :] / mol.d0,
         c=c,
         lw=1,
         alpha=0.6,
@@ -78,7 +79,7 @@ for c, rgbi, transition_elements in zip(cs, rgbis, h):
     for eigindex in range(32, 128):
         colours = np.zeros((B.shape[0], 4))
         colours[:, rgbi] = 1
-        colours[:, 3] = transition_elements[:, groundstate, eigindex] / mol.d0
+        colours[:, 3] = transition_elements[:, 0, eigindex] / mol.d0
         colorline(axul, B / GAUSS, eigenenergies[:, eigindex] / MHz, colors=colours)
 
 axdl.plot(B / GAUSS, eigenenergies[:, groundstate] / MHz, c="red", lw=1, alpha=0.5)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-  "numpy",
+  "numpy>=2.3.5",
   "sympy",
   "scipy"
 ]

--- a/src/diatomic/systems.py
+++ b/src/diatomic/systems.py
@@ -153,7 +153,7 @@ class SingletSigmaMolecule:
             # https://journals.aps.org/prl/pdf/10.1103/PhysRevLett.109.230403
             # All other parameters are from Aldegunde et al., PRA 96, 042506 (2017)
             # https://journals.aps.org/pra/abstract/10.1103/PhysRevA.96.042506
-            "Ii": (HalfInt(of=4), HalfInt(of=3)),
+            "Ii": (HalfInt(of=8), HalfInt(of=3)),
             "d0": 0.566 * DebyeSI,
             "Brot": 1113.950e6 * h,
             "Drot": 0 * h,
@@ -202,7 +202,7 @@ class SingletSigmaMolecule:
             # https://journals.aps.org/pra/abstract/10.1103/PhysRevA.96.042506
             "Ii": (HalfInt(of=3), HalfInt(of=7)),
             "d0": 4.53 * DebyeSI,  # Theory value
-            "Brot": 0.962e9 * h,
+            "Brot": 1.735616e9 * h,
             "Drot": 0 * h,
             "Qi": (-0.097e6 * h, 0.150e6 * h),
             "Ci": (14.2 * h, 854.5 * h),


### PR DESCRIPTION
1. Updated constants for NaCs with value from http://arxiv.org/abs/2512.14511
2. Fixed factor of 2 error in 40K spin in 40K87Rb constants
3. Fixed indexing error in zeeman.py example
4. updated toml file so that numpy version is specified to avoid running on broken 2.3.3 version 